### PR TITLE
Fix italian translation of  "On backorder..."

### DIFF
--- a/install-dev/langs/it/data/order_state.xml
+++ b/install-dev/langs/it/data/order_state.xml
@@ -33,11 +33,11 @@
     <template>payment_error</template>
   </order_state>
   <order_state id="On_backorder_paid">
-    <name>In attesa di rifornimento</name>
+    <name>In attesa di rifornimento (pagato)</name>
     <template>outofstock</template>
   </order_state>
   <order_state id="On_backorder_unpaid">
-    <name>In attesa di rifornimento</name>
+    <name>In attesa di rifornimento (non pagato)</name>
     <template>outofstock</template>
   </order_state>
   <order_state id='Awaiting_bank_wire_payment'>


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions | Answers |
| --- | --- |
| Branch? | develop, 1.6.X |
| Description? | If you use the Italian language in the BO and select `Orders -> Statuses`, you see two identical order statuses _In attesa di rifornimento_, while they are distict _On backorder (paid)_ and _On backorder (unpaid)_. |
| Type? | bug fix |
| Category? | LO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | (see Description above) |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
#### Important guidelines
- Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
- Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
- Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!

The order states "On backorder (paid)" and "On backorder (unpaid)" had the same identical translation in the Italian l10n.
